### PR TITLE
bump new version 7.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Elasticsearch plugin which only provides a TokenFilter that merges tokens in a token stream back into one. Taken from http://elasticsearch-users.115913.n3.nabble.com/Is-there-a-concatenation-filter-td3711094.html
 
 ## ElasticSearch version support
-This plugin is compatible with ES 7.9.3. 
+This plugin is compatible with ES 7.13.1.
 
 ## Build
 To build .zip or .jar for this plugin, run following command and you should see generated files in `/target`
@@ -12,7 +12,7 @@ To build .zip or .jar for this plugin, run following command and you should see 
 ## Install
 To install on your current ES node, use the plugin binary provided in the bin folder (on Ubuntu it should be under `/usr/share/elasticsearch/bin`)
 
-    bin/elasticsearch-plugin  install file:<path to generated zip>/elasticsearch-concatenate-7.9.3.zip
+    bin/elasticsearch-plugin  install file:<path to generated zip>/elasticsearch-concatenate-7.13.1.zip
     
 ## Usage
 The plugin provides a token filter of type `concatenate` which has one parameter `token_separator`, which defaults to ' '. Use it in your custom analyzers to merge tokenized strings back into one single token (usually after applying stemming or other token filters).

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>elasticsearch.concatenate</groupId>
 	<artifactId>elasticsearch-concatenate</artifactId>
-	<version>7.12.1</version>
+	<version>7.13.1</version>
 	<packaging>jar</packaging>
 	<description>Plugin that provides a Token Filter that recombines all of the tokens in a token stream back into one.</description>
 	<inceptionYear>2015</inceptionYear>
@@ -19,7 +19,7 @@
 	</licenses>
 
 	<properties>
-		<elasticsearch.version>7.12.1</elasticsearch.version>
+		<elasticsearch.version>7.13.1</elasticsearch.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<skipTests>false</skipTests>
 		<skipUnitTests>${skipTests}</skipUnitTests>


### PR DESCRIPTION
new build tested with latest ES 7.13.1 - https://github.com/khrvi/elasticsearch-concatenate-token-filter/releases